### PR TITLE
Update-Helm-Repo use S3 creds from secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ A pipeline for deploying the Control Panel frontend to the alpha cluster.
 </tbody>
 </table>
 
-### [`update-helm-repo.yaml`](update-helm-repo.yaml)
+### [`update-helm-repo.yaml`](alpha/update-helm-repo.yaml)
 ```sh
-fly -t default set-pipeline -p update-helm-repo -c update-helm-repo.yaml -v s3-bucket=moj-analytics-helm-repo -v aws-region=eu-west-1
+fly -t default set-pipeline -p update-helm-repo -c alpha/update-helm-repo.yaml -v s3-bucket=moj-analytics-helm-repo -v aws-region=eu-west-1
 ```
 A pipeline to keep our Helm repository up-to-date.
 <table>

--- a/alpha/update-helm-repo.yaml
+++ b/alpha/update-helm-repo.yaml
@@ -29,7 +29,8 @@ jobs:
           aws s3 cp s3://${BUCKET}/index.yaml output/index.yaml
       outputs:
       - name: output
-      output_mapping: {output: existing-index}
+    output_mapping:
+      output: existing-index
 
   - task: package-charts
     config:
@@ -77,7 +78,11 @@ jobs:
         source:
           repository: anigeo/awscli
       params:
+        AWS_ACCESS_KEY_ID: ((aws.iam-put-object-helm-repo-bucket-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((aws.iam-put-object-helm-repo-bucket-secret-access-key))
         BUCKET: ((s3-bucket))
+        AWS_REGION: ((aws-region))
+
       run:
         path: sh
         args:


### PR DESCRIPTION
This changes the update-helm-repo.yaml pipeline to get it's AWS credentials from
concourse secrets instead of directly relying on the nodes role. The setting of
these secrets is done in the [concourse-admin-team](https://github.com/ministryofjustice/analytics-platform-helm-charts/tree/master/charts/concourse-admin-team) helm chart.