### PR TITLE
Deploy cpanel docker image with github sha tag

### DIFF
--- a/dev/cpanel-api.yaml
+++ b/dev/cpanel-api.yaml
@@ -4,14 +4,16 @@ jobs:
   plan:
   - get: docker-image
     trigger: true
-  - get: helm-values
+  - aggregate:
+    - get: source
+    - get: helm-values
   - put: helm-release
     params:
       chart: mojanalytics/cpanel
       values:
       - helm-values/chart-env-config/dev/cpanel.yml
       override_values:
-      - { key: image.tag, path: docker-image/tag }
+      - { key: image.tag, path: source/.git/ref }
       - { key: branch, value: master }
       - { key: tags.branch, value: false }
 
@@ -42,6 +44,12 @@ resources:
     repos:
     - name: mojanalytics
       url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com
+
+- name: source
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/analytics-platform-control-panel.git
+    branch: master
 
 resource_types:
 - name: helm


### PR DESCRIPTION
Deploying the `master` tag seems to not always trigger a replicaset replacement, so we use the github ref as the docker image tag to force the replicaset to be recreated