### PR TITLE
Correct branch name from metadata in git-list-updated-dags

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -168,7 +168,7 @@ jobs:
           git clone https://moj-analytical-services:$GITHUB_TOKEN@github.com/moj-analytical-services/airflow-dags.git
           cd $(pwd)/airflow-dags
           git fetch --all
-          branch=$(jq -r '.[2] | .value' $(pwd)/../resource-dags-pr/.git/resource/metadata.json)
+          branch=$(cat $(pwd)/../resource-dags-pr/.git/resource/head_name)
           git checkout $branch
           git diff --name-only master | grep -v '/' | grep .py
           git diff --name-only master | grep -v '/' | grep .py > $(pwd)/../dag-list.txt


### PR DESCRIPTION
The order of the metadata in [github-org-resource](https://github.com/telia-oss/github-pr-resource/) has been [changed](https://github.com/telia-oss/github-pr-resource/commit/735beaf89ec16b8e3819bc6c7f52028b9b95cdff). This means that the head name used to switch to the relevant branch in a PR is accessed using the wrong index.

This is giving rise to errors like the following, however these do not cause the pipeline to fail:
```
Fetching origin
error: pathspec 'https://github.com/moj-analytical-services/airflow-dags/pull/665' did not match any file(s) known to git
```

This should return something like:
```
Fetching origin
Branch 'my-branch' set up to track remote branch 'my-branch' from 'origin'.
Switched to a new branch 'my-branch'
airflow-dag.py
Updated DAG files
airflow-dag.py
__init__.py
```

See also https://github.com/ministryofjustice/analytics-platform-concourse-github-org-resource/pull/40.