### PR TITLE
Update the airflow image

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -25,7 +25,7 @@ jobs:
           type: docker-image
           source:
             repository: quay.io/mojanalytics/airflow
-            tag: 1.10.3
+            tag: 1.10.10
         params:
           AIRFLOW__CORE__DAGS_FOLDER: ./resource-dags-pr
           AIRFLOW__CORE__LOAD_EXAMPLES: "false"
@@ -47,7 +47,7 @@ jobs:
           type: docker-image
           source:
             repository: quay.io/mojanalytics/airflow
-            tag: 1.10.3
+            tag: 1.10.10
         params:
           AIRFLOW__CORE__DAGS_FOLDER: ./resource-dags-pr
           AIRFLOW__CORE__LOAD_EXAMPLES: "false"
@@ -195,7 +195,7 @@ jobs:
         type: docker-image
         source:
           repository: quay.io/mojanalytics/airflow
-          tag: 1.10.3
+          tag: 1.10.10
       params:
         AIRFLOW__CORE__DAGS_FOLDER: ./airflow-dags
         AIRFLOW__CORE__LOAD_EXAMPLES: "false"


### PR DESCRIPTION
The deployed Airflow instance is already using the latest version of the Airflow docker image, [1.10.10](https://github.com/ministryofjustice/analytics-platform-airflow-docker-image/releases/tag/1.10.10).

This updates the image used by the checks in the Airflow Concourse pipeline to the same version, as per the [instructions](https://github.com/moj-analytical-services/data-engineering/wiki/Airflow#update-the-concourse-pipeline) in the Data Engineering wiki.
