### PR TITLE
Change to pull concourse pipeline images from ECR

### DIFF
--- a/airflow.yaml
+++ b/airflow.yaml
@@ -110,7 +110,7 @@ jobs:
       image_resource:
         type: docker-image
         source:
-          repository: governmentpaas/awscli
+          repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/awscli
           tag: latest
       params:
         AWS_ACCESS_KEY_ID: ((secrets.iam-list-roles-key-id))
@@ -262,7 +262,7 @@ resource_types:
   - name: pull-request
     type: docker-image
     source:
-      repository: teliaoss/github-pr-resource
+      repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/concourse-github-pr-resource
 
 resources:
 - name: resource-dags-pr

--- a/alpha/cpanel-api.yaml
+++ b/alpha/cpanel-api.yaml
@@ -74,5 +74,5 @@ resource_types:
   - name: helm
     type: docker-image
     source:
-      repository: linkyard/concourse-helm-resource
+      repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/concourse-helm-resource
       tag: 2.13.1

--- a/alpha/update-helm-repo.yaml
+++ b/alpha/update-helm-repo.yaml
@@ -17,7 +17,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: anigeo/awscli
+              repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/anigeo-awscli
           params:
             BUCKET: ((s3-bucket))
           run:
@@ -37,7 +37,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: lachlanevenson/k8s-helm
+              repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/lachlanevenson-k8s-helm
               tag: v2.9.1
           params:
             BUCKET: ((s3-bucket))
@@ -75,7 +75,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: anigeo/awscli
+              repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/anigeo-awscli
           params:
             AWS_ACCESS_KEY_ID: ((aws.iam-put-object-helm-repo-bucket-access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws.iam-put-object-helm-repo-bucket-secret-access-key))

--- a/dev/cpanel-api.yaml
+++ b/dev/cpanel-api.yaml
@@ -55,5 +55,5 @@ resource_types:
   - name: helm
     type: docker-image
     source:
-      repository: linkyard/concourse-helm-resource
+      repository: 593291632749.dkr.ecr.eu-west-1.amazonaws.com/concourse-helm-resource
       tag: 2.13.1


### PR DESCRIPTION
In order to reduce the number of docker images we pull from docker hub, this changes the concourse pipelines for airflow, control panel and helm chart packaging to use images from ECR