### PR TITLE
Revert helm release name for cpanel to cpanel-master

### DIFF
--- a/alpha/cpanel-api.yaml
+++ b/alpha/cpanel-api.yaml
@@ -65,7 +65,7 @@ resources:
       helm_host: tiller-deploy.kube-system:44134
       token: ((kubernetes.token))
       namespace: default
-      release: cpanel-main
+      release: cpanel-master
       repos:
         - name: mojanalytics
           url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com

--- a/alpha/cpanel-api.yaml
+++ b/alpha/cpanel-api.yaml
@@ -28,7 +28,7 @@ jobs:
             - cpanel-helm-config/chart-env-config/alpha/cpanel.yml
           override_values:
             - { key: image.tag, path: release/commit_sha }
-            - { key: branch, value: main }
+            - { key: branch, value: master }
             - { key: tags.branch, value: false }
 
 resources:

--- a/dev/cpanel-api.yaml
+++ b/dev/cpanel-api.yaml
@@ -40,7 +40,7 @@ resources:
       helm_host: tiller-deploy.kube-system:44134
       token: ((kubernetes.token))
       namespace: default
-      release: cpanel-main
+      release: cpanel-master
       repos:
         - name: mojanalytics
           url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com

--- a/dev/cpanel-api.yaml
+++ b/dev/cpanel-api.yaml
@@ -14,7 +14,7 @@ jobs:
             - helm-values/chart-env-config/dev/cpanel.yml
           override_values:
             - { key: image.tag, path: source/.git/ref }
-            - { key: branch, value: main }
+            - { key: branch, value: master }
             - { key: tags.branch, value: false }
 
 resources:


### PR DESCRIPTION
In order to be able to upgrade (and rollback if necessary) we should retain the helm release name for cpanel to be cpanel-master