### PR TITLE
Fix helm stable repo for cpanel alpha concourse pipeline

### DIFF
--- a/alpha/cpanel-api.yaml
+++ b/alpha/cpanel-api.yaml
@@ -69,6 +69,7 @@ resources:
       repos:
         - name: mojanalytics
           url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com
+      stable_repo: https://charts.helm.sh/stable    
 
 resource_types:
   - name: helm

--- a/dev/cpanel-api.yaml
+++ b/dev/cpanel-api.yaml
@@ -44,6 +44,7 @@ resources:
       repos:
         - name: mojanalytics
           url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com
+      stable_repo: https://charts.helm.sh/stable      
 
   - name: source
     type: git


### PR DESCRIPTION
Fix helm stable repo

This is a fix for a helm error that started today when deploying the control panel:

```
Initializing helm...

Error: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```

This was due to Google getting rid of the 'stable repo' that Helm v2 uses. See: hashicorp/terraform-provider-helm#649 (It was deprecated in Oct).

By setting a different, valid stable_repo, helm works.